### PR TITLE
Simplify used eeprom interface in algorithm

### DIFF
--- a/NAV_Algorithms/AHRS.cpp
+++ b/NAV_Algorithms/AHRS.cpp
@@ -399,12 +399,8 @@ void AHRS_type::write_calibration_into_EEPROM( void)
   if( !magnetic_calibration_updated)
     return;
 
-  lock_EEPROM( false);
-
   compass_calibration.write_into_EEPROM();
   magnetic_calibration_updated = false; // done ...
-
-  lock_EEPROM( true);
 }
 
 void AHRS_type::handle_magnetic_calibration ( void)

--- a/NAV_Algorithms/compass_calibration.h
+++ b/NAV_Algorithms/compass_calibration.h
@@ -175,8 +175,6 @@ public:
     if( calibration_done == false)
       return;
 
-    EEPROM_initialize();
-
     float variance = 0.0f;
     for( unsigned i=0; i<3; ++i)
       {

--- a/NAV_Algorithms/organizer.h
+++ b/NAV_Algorithms/organizer.h
@@ -108,11 +108,9 @@ public:
     eulerangle<float> new_euler = q_new_setting;
 
     // make the change permanent
-    lock_EEPROM( false);
     write_EEPROM_value( SENS_TILT_ROLL,  new_euler.roll);
     write_EEPROM_value( SENS_TILT_PITCH, new_euler.pitch);
     write_EEPROM_value( SENS_TILT_YAW,   new_euler.yaw);
-    lock_EEPROM( true);
   }
 
   void initialize_before_measurement( void)

--- a/NAV_Algorithms/organizer.h
+++ b/NAV_Algorithms/organizer.h
@@ -81,11 +81,9 @@ public:
     eulerangle<float> euler = q;
 
     // make the change permanent
-    lock_EEPROM( false);
     write_EEPROM_value( SENS_TILT_ROLL,  euler.roll);
     write_EEPROM_value( SENS_TILT_PITCH, euler.pitch);
     write_EEPROM_value( SENS_TILT_YAW,   euler.yaw);
-    lock_EEPROM( true);
   }
 
   void initialize_before_measurement( void)

--- a/NAV_Algorithms/persistent_data.h
+++ b/NAV_Algorithms/persistent_data.h
@@ -95,8 +95,6 @@ const persistent_data_t * find_parameter_from_ID( EEPROM_PARAMETER_ID id);
 float configuration( EEPROM_PARAMETER_ID id);
 bool write_EEPROM_value( EEPROM_PARAMETER_ID id, float value);
 bool read_EEPROM_value( EEPROM_PARAMETER_ID id, float &value);
-bool lock_EEPROM( bool lockit);
-bool EEPROM_initialize( void);
 void ensure_EEPROM_parameter_integrity(void);
 
 extern const persistent_data_t PERSISTENT_DATA[];


### PR DESCRIPTION
The lib shall not know details about the EEPROM implementation and shall not be responsible for locking or unlocking the Flash. 
This has been simplified here. 

This pull request is required before merging the changes in sw_sensor where flash access complexity is centralized in eeprom.cpp .  https://github.com/larus-breeze/sw_sensor/compare/master...issue_117) 